### PR TITLE
Halved memory usage for most applications

### DIFF
--- a/src/blade.c
+++ b/src/blade.c
@@ -182,6 +182,7 @@ static void repl(b_vm *vm) {
       memset(source, 0, strlen(source));
     }
   }
+  free(source);
 }
 
 static void run_file(b_vm *vm, const char *file) {

--- a/src/blade_file.c
+++ b/src/blade_file.c
@@ -89,7 +89,7 @@ DECLARE_NATIVE(file) {
     mode = (b_obj_string *) GC(copy_string(vm, "r", 1));
   }
 
-  b_obj_file *file = new_file(vm, path, mode);
+  b_obj_file *file = (b_obj_file*)GC(new_file(vm, path, mode));
   file_open(file);
 
   RETURN_OBJ(file);

--- a/src/blade_list.c
+++ b/src/blade_list.c
@@ -2,7 +2,7 @@
 
 #include <stdlib.h>
 
-void write_list(b_vm *vm, b_obj_list *list, b_value value) {
+inline void write_list(b_vm *vm, b_obj_list *list, b_value value) {
   write_value_arr(vm, &list->items, value);
 }
 

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -21,7 +21,7 @@
 // see: https://engineering.fb.com/2019/04/25/developer-tools/f14/
 #define TABLE_MAX_LOAD 0.85714286
 
-#define GC_HEAP_GROWTH_FACTOR 2
+#define GC_HEAP_GROWTH_FACTOR 1.5
 
 #define USE_NAN_BOXING 1
 #define PCRE2_STATIC

--- a/src/memory.c
+++ b/src/memory.c
@@ -125,6 +125,7 @@ void blacken_object(b_vm *vm, b_obj *object) {
       mark_table(vm, &klass->methods);
       mark_table(vm, &klass->properties);
       mark_table(vm, &klass->static_properties);
+      mark_value(vm, klass->initializer);
       break;
     }
     case OBJ_CLOSURE: {
@@ -222,6 +223,9 @@ void free_object(b_vm *vm, b_obj *object) {
       free_table(vm, &klass->methods);
       free_table(vm, &klass->properties);
       free_table(vm, &klass->static_properties);
+      if(!IS_EMPTY(klass->initializer)) {
+        free_object(vm, AS_OBJ(klass->initializer));
+      }
       FREE(b_obj_class, object);
       break;
     }
@@ -236,9 +240,9 @@ void free_object(b_vm *vm, b_obj *object) {
     case OBJ_FUNCTION: {
       b_obj_func *function = (b_obj_func *) object;
       free_blob(vm, &function->blob);
-      /*if(function->name != NULL) {
+      if(function->name != NULL) {
         free_object(vm, (b_obj *) function->name);
-      }*/
+      }
       FREE(b_obj_func, object);
       break;
     }

--- a/src/memory.h
+++ b/src/memory.h
@@ -4,7 +4,7 @@
 #include "common.h"
 #include "vm.h"
 
-#define GROW_CAPACITY(capacity) ((capacity) < 8 ? 8 : (capacity)*2)
+#define GROW_CAPACITY(capacity) ((capacity) < 4 ? 4 : (capacity)*2)
 
 #define GROW_ARRAY(type, pointer, old_count, new_count)                        \
   (type *)reallocate(vm, pointer, sizeof(type) * (old_count),                  \

--- a/src/module.c
+++ b/src/module.c
@@ -21,7 +21,7 @@ void bind_native_modules(b_vm *vm) {
     b_module_reg *module = modules[i](vm);
 
     if(module != NULL) {
-      b_obj_module *the_module = new_module(vm, strdup(module->name), strdup("<__native__>"));
+      b_obj_module *the_module = (b_obj_module*)GC(new_module(vm, strdup(module->name), strdup("<__native__>")));
       the_module->preloader = module->preloader;
       the_module->unloader = module->unloader;
 
@@ -98,4 +98,6 @@ void bind_native_modules(b_vm *vm) {
       // @TODO: Warn about module loading error...
     }
   }
+
+  CLEAR_GC();
 }

--- a/src/object.h
+++ b/src/object.h
@@ -101,19 +101,19 @@ struct s_obj_string {
 
 typedef struct b_obj_up_value {
   b_obj obj;
-  b_value *location;
   b_value closed;
+  b_value *location;
   struct b_obj_up_value *next;
 } b_obj_up_value;
 
 typedef struct {
   b_obj obj;
   bool imported;
+  b_table values;
   char *name;
   char *file;
   void *preloader;
   void *unloader;
-  b_table values;
 } b_obj_module;
 
 typedef struct {
@@ -137,17 +137,17 @@ typedef struct {
 typedef struct b_obj_class {
   b_obj obj;
   b_value initializer;
-  b_obj_string *name;
   b_table properties;
   b_table static_properties;
   b_table methods;
+  b_obj_string *name;
   struct b_obj_class *superclass;
 } b_obj_class;
 
 typedef struct {
   b_obj obj;
-  b_obj_class *klass;
   b_table properties;
+  b_obj_class *klass;
 } b_obj_instance;
 
 typedef struct {

--- a/src/value.c
+++ b/src/value.c
@@ -14,12 +14,12 @@ void init_value_arr(b_value_arr *array) {
   array->values = NULL;
 }
 
-inline void init_byte_arr(b_byte_arr *array, int length) {
+void init_byte_arr(b_byte_arr *array, int length) {
   array->count = length;
   array->bytes = (unsigned char *) calloc(length, sizeof(unsigned char));
 }
 
-inline void write_value_arr(b_vm *vm, b_value_arr *array, b_value value) {
+void write_value_arr(b_vm *vm, b_value_arr *array, b_value value) {
   if (array->capacity < array->count + 1) {
     int old_capacity = array->capacity;
     array->capacity = GROW_CAPACITY(old_capacity);
@@ -59,12 +59,12 @@ void insert_value_arr(b_vm *vm, b_value_arr *array, b_value value, int index) {
   array->count++;
 }
 
-inline void free_value_arr(b_vm *vm, b_value_arr *array) {
+void free_value_arr(b_vm *vm, b_value_arr *array) {
   FREE_ARRAY(b_value, array->values, array->capacity);
   init_value_arr(array);
 }
 
-inline void free_byte_arr(b_vm *vm, b_byte_arr *array) {
+void free_byte_arr(b_vm *vm, b_byte_arr *array) {
   FREE_ARRAY(unsigned char, array->bytes, array->count);
 }
 

--- a/src/value.c
+++ b/src/value.c
@@ -14,12 +14,12 @@ void init_value_arr(b_value_arr *array) {
   array->values = NULL;
 }
 
-void init_byte_arr(b_byte_arr *array, int length) {
+inline void init_byte_arr(b_byte_arr *array, int length) {
   array->count = length;
   array->bytes = (unsigned char *) calloc(length, sizeof(unsigned char));
 }
 
-void write_value_arr(b_vm *vm, b_value_arr *array, b_value value) {
+inline void write_value_arr(b_vm *vm, b_value_arr *array, b_value value) {
   if (array->capacity < array->count + 1) {
     int old_capacity = array->capacity;
     array->capacity = GROW_CAPACITY(old_capacity);
@@ -59,12 +59,12 @@ void insert_value_arr(b_vm *vm, b_value_arr *array, b_value value, int index) {
   array->count++;
 }
 
-void free_value_arr(b_vm *vm, b_value_arr *array) {
+inline void free_value_arr(b_vm *vm, b_value_arr *array) {
   FREE_ARRAY(b_value, array->values, array->capacity);
   init_value_arr(array);
 }
 
-void free_byte_arr(b_vm *vm, b_byte_arr *array) {
+inline void free_byte_arr(b_vm *vm, b_byte_arr *array) {
   FREE_ARRAY(unsigned char, array->bytes, array->count);
 }
 


### PR DESCRIPTION
This PR will drop intensive memory usage for most long running processes especially those that involve a lot of class instantiation. "Non-long-running" applications should also see a good drop in memory usage.

This PR changes the GC growth rate to increase by half of the current value instead of double of it. It also reduces the default object capacity from 8 to 4.