### PR TITLE
Added instance class method list to `getprop()` search

### DIFF
--- a/src/native.c
+++ b/src/native.c
@@ -133,8 +133,11 @@ DECLARE_NATIVE(getprop) {
 
   b_obj_instance *instance = AS_INSTANCE(args[0]);
   b_value value;
-  table_get(&instance->properties, args[1], &value);
-  RETURN_VALUE(value);
+  if(table_get(&instance->properties, args[1], &value) ||
+      table_get(&instance->klass->methods, args[1], &value)) {
+    RETURN_VALUE(value);
+  }
+  RETURN;
 }
 
 /**


### PR DESCRIPTION
Added instance class method list to `getprop()` search and fixed numeric overflow results when prop is not found.

This change allows the use of `getprop()` to access decorators as well, providing an access point to library implementers who want to use decorators to offer streamlined features from their package/modules.