### PR TITLE
Changing the default return value of a function from nil to nothing.

### DIFF
--- a/src/blade_dict.c
+++ b/src/blade_dict.c
@@ -111,7 +111,7 @@ DECLARE_DICT_METHOD(get) {
   b_value value;
   if (!dict_get_entry(dict, args[0], &value)) {
     if (arg_count == 1) {
-      RETURN;
+      RETURN_NIL;
     } else {
       RETURN_VALUE(args[1]); // return default
     }
@@ -164,7 +164,7 @@ DECLARE_DICT_METHOD(remove) {
     dict->names.count--;
     RETURN_VALUE(value);
   }
-  RETURN;
+  RETURN_NIL;
 }
 
 DECLARE_DICT_METHOD(is_empty) {
@@ -209,7 +209,7 @@ DECLARE_DICT_METHOD(__iter__) {
     RETURN_VALUE(result);
   }
 
-  RETURN;
+  RETURN_NIL;
 }
 
 DECLARE_DICT_METHOD(__itern__) {
@@ -227,7 +227,7 @@ DECLARE_DICT_METHOD(__itern__) {
     }
   }
 
-  RETURN;
+  RETURN_NIL;
 }
 
 #undef ENFORCE_VALID_DICT_KEY

--- a/src/blade_list.c
+++ b/src/blade_list.c
@@ -101,7 +101,7 @@ DECLARE_LIST_METHOD(pop) {
     list->items.count--;
     RETURN_VALUE(value);
   }
-  RETURN;
+  RETURN_NIL;
 }
 
 DECLARE_LIST_METHOD(shift) {
@@ -116,7 +116,7 @@ DECLARE_LIST_METHOD(shift) {
   b_obj_list *list = AS_LIST(METHOD_OBJECT);
   if (count >= list->items.count || list->items.count == 1) {
     list->items.count = 0;
-    RETURN;
+    RETURN_NIL;
   } else if (count > 0) {
     b_obj_list *n_list = (b_obj_list *) GC(new_list(vm));
     for (int i = 0; i < count; i++) {
@@ -133,7 +133,7 @@ DECLARE_LIST_METHOD(shift) {
       RETURN_OBJ(n_list);
     }
   }
-  RETURN;
+  RETURN_NIL;
 }
 
 DECLARE_LIST_METHOD(remove_at) {
@@ -253,7 +253,7 @@ DECLARE_LIST_METHOD(first) {
   if (list->items.count > 0) {
     RETURN_VALUE(list->items.values[0]);
   } else {
-    RETURN;
+    RETURN_NIL;
   }
 }
 
@@ -263,7 +263,7 @@ DECLARE_LIST_METHOD(last) {
   if (list->items.count > 0) {
     RETURN_VALUE(list->items.values[list->items.count - 1]);
   } else {
-    RETURN;
+    RETURN_NIL;
   }
 }
 
@@ -391,7 +391,7 @@ DECLARE_LIST_METHOD(__iter__) {
     RETURN_VALUE(list->items.values[index]);
   }
 
-  RETURN;
+  RETURN_NIL;
 }
 
 DECLARE_LIST_METHOD(__itern__) {
@@ -414,5 +414,5 @@ DECLARE_LIST_METHOD(__itern__) {
     RETURN_NUMBER((double) index + 1);
   }
 
-  RETURN;
+  RETURN_NIL;
 }

--- a/src/blade_range.c
+++ b/src/blade_range.c
@@ -23,7 +23,7 @@ DECLARE_RANGE_METHOD(__iter__) {
     RETURN_NUMBER(range->lower > range->upper ? --range->lower : ++range->lower);
   }
 
-  RETURN;
+  RETURN_NIL;
 }
 
 DECLARE_RANGE_METHOD(__itern__) {
@@ -32,7 +32,7 @@ DECLARE_RANGE_METHOD(__itern__) {
 
   if (IS_NIL(args[0])) {
     if (range->range == 0) {
-      RETURN;
+      RETURN_NIL;
     }
     RETURN_NUMBER(0);
   }
@@ -46,5 +46,5 @@ DECLARE_RANGE_METHOD(__itern__) {
     RETURN_NUMBER(index);
   }
 
-  RETURN;
+  RETURN_NIL;
 }

--- a/src/blade_string.c
+++ b/src/blade_string.c
@@ -1010,7 +1010,7 @@ DECLARE_STRING_METHOD(__iter__) {
     RETURN_L_STRING(string->chars + start, (int) (end - start));
   }
 
-  RETURN;
+  RETURN_NIL;
 }
 
 DECLARE_STRING_METHOD(__itern__) {
@@ -1033,5 +1033,5 @@ DECLARE_STRING_METHOD(__itern__) {
     RETURN_NUMBER((double) index + 1);
   }
 
-  RETURN;
+  RETURN_NIL;
 }

--- a/src/bytes.c
+++ b/src/bytes.c
@@ -279,7 +279,7 @@ DECLARE_BYTES_METHOD(__iter__) {
     RETURN_NUMBER((int) bytes->bytes.bytes[index]);
   }
 
-  RETURN;
+  RETURN_NIL;
 }
 
 DECLARE_BYTES_METHOD(__itern__) {
@@ -300,5 +300,5 @@ DECLARE_BYTES_METHOD(__itern__) {
     RETURN_NUMBER((double) index + 1);
   }
 
-  RETURN;
+  RETURN_NIL;
 }

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -284,7 +284,7 @@ static void emit_return(b_parser *p) {
   if (p->vm->compiler->type == TYPE_INITIALIZER) {
     emit_byte_and_short(p, OP_GET_LOCAL, 0);
   } else {
-    emit_byte(p, OP_NIL);
+    emit_byte(p, OP_EMPTY);
   }
   emit_byte(p, OP_RETURN);
 }

--- a/src/native.c
+++ b/src/native.c
@@ -137,7 +137,7 @@ DECLARE_NATIVE(getprop) {
       table_get(&instance->klass->methods, args[1], &value)) {
     RETURN_VALUE(value);
   }
-  RETURN;
+  RETURN_NIL;
 }
 
 /**
@@ -733,6 +733,8 @@ DECLARE_NATIVE(print) {
       printf(" ");
     }
   }
-//  printf("\n");
+  if(vm->is_repl) {
+    printf("\n");
+  }
   RETURN;
 }

--- a/src/native.h
+++ b/src/native.h
@@ -54,7 +54,8 @@
 
 #define NORMALIZE(token) NORMALIZE_##token
 
-#define RETURN { args[-1] = NIL_VAL; return true; }
+#define RETURN { args[-1] = EMPTY_VAL; return true; }
+#define RETURN_NIL { args[-1] = NIL_VAL; return true; }
 #define RETURN_EMPTY { args[-1] = NIL_VAL; return false; }
 #define RETURN_ERROR(...)                                                      \
   {                                                                            \

--- a/src/standard/base64.c
+++ b/src/standard/base64.c
@@ -120,7 +120,7 @@ DECLARE_MODULE_METHOD(base64__decode) {
   unsigned char *data = base64_decode((const char *) string->chars,
                                       string->length, &output_length);
 
-  if (data == NULL) RETURN;
+  if (data == NULL) RETURN_NIL;
 
   b_obj_bytes *bytes = new_bytes(vm, output_length);
   memcpy(bytes->bytes.bytes, data, output_length);
@@ -139,7 +139,7 @@ DECLARE_MODULE_METHOD(base64__encode) {
   char *data = base64_encode((const unsigned char *) bytes->bytes.bytes,
                              bytes->bytes.count, &output_length);
 
-  if (data == NULL) RETURN;
+  if (data == NULL) RETURN_NIL;
 
   RETURN_T_STRING(data, output_length);
 }

--- a/src/standard/os.c
+++ b/src/standard/os.c
@@ -50,11 +50,11 @@ DECLARE_MODULE_METHOD(os_exec) {
   ENFORCE_ARG_TYPE(exec, 0, IS_STRING);
   b_obj_string *string = AS_STRING(args[0]);
   if (string->length == 0) {
-    RETURN;
+    RETURN_NIL;
   }
 
   FILE *fd = popen(string->chars, "r");
-  if (!fd) RETURN;
+  if (!fd) RETURN_NIL;
 
   char buffer[256];
   size_t n_read;
@@ -81,7 +81,7 @@ DECLARE_MODULE_METHOD(os_exec) {
 
     if (length == 0) {
       pclose(fd);
-      RETURN;
+      RETURN_NIL;
     }
 
     output[length - 1] = '\0';
@@ -203,7 +203,7 @@ DECLARE_MODULE_METHOD(os_getenv) {
   if (env != NULL) {
     RETURN_STRING(env);
   } else {
-    RETURN;
+    RETURN_NIL;
   }
 }
 

--- a/src/standard/socket.c
+++ b/src/standard/socket.c
@@ -66,7 +66,7 @@ DECLARE_MODULE_METHOD(socket__error) {
     char *error = strerror(errno);
     RETURN_STRING(error);
   }
-  RETURN;
+  RETURN_NIL;
 }
 
 DECLARE_MODULE_METHOD(socket__create) {
@@ -352,7 +352,7 @@ DECLARE_MODULE_METHOD(socket__recv) {
     RETURN_NUMBER(-1);
   }
 
-  RETURN;
+  RETURN_NIL;
 }
 
 DECLARE_MODULE_METHOD(socket__setsockopt) {
@@ -407,7 +407,7 @@ DECLARE_MODULE_METHOD(socket__getsockopt) {
       getsockopt(sock, SOL_SOCKET, SO_ERROR, (char *)&so_error, &len);
 #endif // !_WIN32
 
-      if (so_error == 0) RETURN;
+      if (so_error == 0) RETURN_NIL;
       char *error = strerror(so_error);
       RETURN_STRING(error);
     }
@@ -499,7 +499,7 @@ DECLARE_MODULE_METHOD(socket__getaddrinfo) {
   WSADATA wsa_data;
   int i_result = WSAStartup(MAKEWORD(1, 1), &wsa_data);
   if (i_result != NO_ERROR) {
-    RETURN;
+    RETURN_NIL;
   }
 #endif
 
@@ -544,7 +544,7 @@ DECLARE_MODULE_METHOD(socket__getaddrinfo) {
     }
   }
 
-  RETURN;
+  RETURN_NIL;
 }
 
 DECLARE_MODULE_METHOD(socket__close) {

--- a/src/value.c
+++ b/src/value.c
@@ -70,8 +70,7 @@ void free_byte_arr(b_vm *vm, b_byte_arr *array) {
 
 static inline void do_print_value(b_value value, bool fix_string) {
 #if defined(USE_NAN_BOXING) && USE_NAN_BOXING
-  if (IS_EMPTY(value))
-    printf("%s", "");
+  if (IS_EMPTY(value)) return;
   else if (IS_NIL(value))
     printf("nil");
   else if (IS_BOOL(value))
@@ -83,7 +82,6 @@ static inline void do_print_value(b_value value, bool fix_string) {
 #else
   switch (value.type) {
   case VAL_EMPTY:
-    printf("%s", "");
     break;
   case VAL_NIL:
     printf("nil");
@@ -180,6 +178,7 @@ bool values_equal(b_value a, b_value b) {
 
   switch (a.type) {
   case VAL_NIL:
+  case VAL_EMPTY:
     return true;
   case VAL_BOOL:
     return AS_BOOL(a) == AS_BOOL(b);

--- a/src/vm.c
+++ b/src/vm.c
@@ -23,6 +23,8 @@
 // for debugging...
 #include "debug.h"
 
+#define ERR_CANT_ASSIGN_EMPTY "empty cannot be assigned."
+
 static inline void reset_stack(b_vm *vm) {
   vm->stack_top = vm->stack;
   vm->frame_count = 0;
@@ -1546,13 +1548,16 @@ b_ptr_result run(b_vm *vm) {
       }
 
       case OP_ECHO: {
+        b_value val = peek(vm, 0);
         if (vm->is_repl) {
-          echo_value(peek(vm, 0));
+          echo_value(val);
         } else {
-          print_value(peek(vm, 0));
+          print_value(val);
+        }
+        if(!IS_EMPTY(val)) {
+          printf("\n");
         }
         pop(vm);
-        printf("\n");
         break;
       }
 
@@ -1588,6 +1593,10 @@ b_ptr_result run(b_vm *vm) {
 
       case OP_DEFINE_GLOBAL: {
         b_obj_string *name = READ_STRING();
+        if(IS_EMPTY(peek(vm, 0))) {
+          runtime_error(ERR_CANT_ASSIGN_EMPTY);
+          break;
+        }
         table_set(vm, &frame->closure->function->module->values, OBJ_VAL(name), peek(vm, 0));
         pop(vm);
 
@@ -1611,6 +1620,11 @@ b_ptr_result run(b_vm *vm) {
       }
 
       case OP_SET_GLOBAL: {
+        if(IS_EMPTY(peek(vm, 0))) {
+          runtime_error(ERR_CANT_ASSIGN_EMPTY);
+          break;
+        }
+
         b_obj_string *name = READ_STRING();
         b_table *table = &frame->closure->function->module->values;
         if (table_set(vm, table, OBJ_VAL(name), peek(vm, 0))) {
@@ -1628,6 +1642,10 @@ b_ptr_result run(b_vm *vm) {
       }
       case OP_SET_LOCAL: {
         uint16_t slot = READ_SHORT();
+        if(IS_EMPTY(peek(vm, 0))) {
+          runtime_error(ERR_CANT_ASSIGN_EMPTY);
+          break;
+        }
         frame->slots[slot] = peek(vm, 0);
         break;
       }
@@ -1841,7 +1859,11 @@ b_ptr_result run(b_vm *vm) {
         if (!IS_INSTANCE(peek(vm, 1)) && !IS_DICT(peek(vm, 1))) {
           runtime_error("object of type %s can not carry properties", value_type(peek(vm, 1)));
           break;
+        } else  if(IS_EMPTY(peek(vm, 0))) {
+          runtime_error(ERR_CANT_ASSIGN_EMPTY);
+          break;
         }
+
         b_obj_string *name = READ_STRING();
 
         if (IS_INSTANCE(peek(vm, 1))) {
@@ -1888,6 +1910,10 @@ b_ptr_result run(b_vm *vm) {
       }
       case OP_SET_UP_VALUE: {
         int index = READ_SHORT();
+        if(IS_EMPTY(peek(vm, 0))) {
+          runtime_error(ERR_CANT_ASSIGN_EMPTY);
+          break;
+        }
         *((b_obj_closure *) frame->closure)->up_values[index]->location =
             peek(vm, 0);
         break;
@@ -2108,6 +2134,11 @@ b_ptr_result run(b_vm *vm) {
 
           b_value value = peek(vm, 0);
           b_value index = peek(vm, 1);
+
+          if(IS_EMPTY(value)) {
+            runtime_error(ERR_CANT_ASSIGN_EMPTY);
+            break;
+          }
 
           switch (AS_OBJ(peek(vm, 2))->type) {
             case OBJ_LIST: {
@@ -2413,3 +2444,5 @@ b_ptr_result interpret(b_vm *vm, b_obj_module *module, const char *source) {
 
   return result;
 }
+
+#undef ERR_CANT_ASSIGN_EMPTY


### PR DESCRIPTION
This PR changes a fundamental part of the Blade language. Formerly, a function implicitly returns nil when there is no override from the `return` keyword, but this PR will cause all functions to return `empty` (nothing) which is represented internally as `EMPTY_VAL` instead.

### Consequence of merging this PR
---

1. Functions no longer implicitly return a value.
2. All existing functions will continue to work normally with except that for codes that make the assumption that there will always be a usable value from the return of a function.
2. The `empty` type is not a user-type and as such cannot be created or assigned to a variable or any object for that matter.
3. This change plays nicely in the REPL mode and removes the previously confusing `nil` prints that accompanies almost all actions.
4. If you plan to use or allow the use of your function as an argument to another function, then the function must explicitly return a value.
5. This PR will close #73 and #74.

## Rollback plan

In the case of contest for the changes in the PR and such contest is approved as agreed upon, the `main` branch can rollback to the branch `rollback` to undo this change.