### PR TITLE
Fix for #98

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,5 @@
 /tmp/
 /venv/
 
-CMakeSettings.json
-
 /.ccls-cache/
+win-test.b

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,26 @@
+﻿{
+  "configurations": [
+    {
+      "name": "Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\build\\${configurationType}",
+      "installRoot": "${projectDir}\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": ""
+    },
+    {
+      "name": "Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\build\\${configurationType}",
+      "installRoot": "${projectDir}\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": ""
+    }
+  ]
+}

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -2202,6 +2202,9 @@ static void try_statement(b_parser *p) {
 
     end_scope(p);
   }
+  else {
+      type = make_constant(p, OBJ_VAL(copy_string(p->vm, "Exception", 9)));
+  }
 
   patch_jump(p, exit_jump);
 


### PR DESCRIPTION
Fixed missing catch in try...catch bug as well as added new CMakeSettings.json for visual studio code build.
This PR fixes #98 by setting a default empty catch body when the catch block is missing in a try...catch...finally.