### PR TITLE
ast: Fix IndexExpr

### DIFF
--- a/libs/ast/expr.b
+++ b/libs/ast/expr.b
@@ -247,16 +247,19 @@ class SetExpr < Expr {
 class IndexExpr < Expr {
 
   /**
+   * @param {Expr|any|nil} expr
    * @param {Expr|any|nil} args
    * @constructor
    */
-  IndexExpr(args) {
+  IndexExpr(expr, args) {
+    self.expr = expr
     self.args = args
   }
 
   @to_json() {
     return {
       type: 'IndexExpr',
+      expr: self.expr,
       args: self.args,
     }
   }

--- a/libs/ast/parser.b
+++ b/libs/ast/parser.b
@@ -238,7 +238,7 @@ class Parser {
 
     self._ignore_newline()
     self._consume(TokenType.RBRACKET, "']' expected at end of indexer")
-    return IndexExpr(args)
+    return IndexExpr(callee, args)
   }
 
   /**

--- a/packages/clib/clib/types.b
+++ b/packages/clib/clib/types.b
@@ -191,12 +191,14 @@ var function = _clib.closure
 
 
 /**
- * Returns a type that can be used to declare structs. 
- * To create or read value for the struct you need to use the `new()` 
+ * Returns a type that can be used to declare structs.
+ * To create or read value for the struct you need to use the `new()`
+ * Returns a type that can be used to declare structs.
+ * To create or read value for the struct you need to use the `new()`
  * and `get()` functions respectively.
- * Alternatively, you may use the `pack()` and `unpack()` 
+ * Alternatively, you may use the `pack()` and `unpack()`
  * function in the `struct` module respectively.
- * 
+ *
  * @note This function can also be used to define a C union or array.
  * @param any... type
  * @returns type
@@ -215,16 +217,40 @@ def struct(...) {
 }
 
 /**
- * Returns a type that can be used to declare structs based on the named 
- * types. The function works well with the `get()` function because it 
- * automatically assigns the name of the struct elements when getting the 
- * value. 
- * 
- * To create or read value for the struct you need to use the `new()` 
+ * Returns a struct type with named fields. The function works well with the `get()`
+ * function because it automatically assigns the name of the struct elements when
+ * getting the value.
+ *
+ * To create or read value for the struct you need to use the `new()`
  * and `get()` functions respectively.
- * Alternatively, you may use the `pack()` and `unpack()` 
+ * Alternatively, you may use the `pack()` and `unpack()`
  * function in the `struct` module respectively.
- * 
+ *
+ * For example, let's say you have the following C struct:
+ * ```c
+ * typedef struct {
+ *   char* message;
+ *   int status;
+ * } custom_error;
+ * ```
+ *
+ * This is how you'd create a named struct for it:
+ * ```blade
+ * import clib
+ *
+ * var lib = clib.load('./custom-library.so')
+ *
+ * var custom_error = clib.named_struct({
+ *   'message': clib.char_ptr,
+ *   'status': clib.int
+ * })
+ *
+ * var myfunction = lib.define('custom_error_function', custom_error)
+ * echo myfunction() # {message: oh no!, status: 1}
+ *
+ * lib.close()
+ * ```
+ *
  * @note This function can also be used to define a C union or array.
  * @param dictionary types
  * @returns type

--- a/packages/clib/clib/types.b
+++ b/packages/clib/clib/types.b
@@ -193,8 +193,6 @@ var function = _clib.closure
 /**
  * Returns a type that can be used to declare structs.
  * To create or read value for the struct you need to use the `new()`
- * Returns a type that can be used to declare structs.
- * To create or read value for the struct you need to use the `new()`
  * and `get()` functions respectively.
  * Alternatively, you may use the `pack()` and `unpack()`
  * function in the `struct` module respectively.

--- a/scripts/ast.b
+++ b/scripts/ast.b
@@ -30,7 +30,7 @@ var asts = {
       Call: ['callee', 'args'],
       Get: ['expr', 'name'],
       Set: ['expr', 'name', 'value'],
-      Index: ['args'],
+      Index: ['expr', 'args'],
       List: ['items'],
       Dict: ['keys', 'values'],
       Interpolation: ['data']


### PR DESCRIPTION
Try running this code:
```
import ast
import json

var tree = ast.parse('array[1] = v', '')
echo json.encode(tree, false)
```

What you'll see is the following:
```json
[
  {
    "type": "ExprStmt",
    "expr": {
      "type": "=",
      "expr": {
        "type": "IndexExpr",
        "args": [
          {
            "type": "LiteralExpr",
            "value": "1"
          }
        ]
      },
      "value": {
        "type": "IdentifierExpr",
        "value": "v"
      }
    }
  }
]
```

As can be seen our identifier `array` (or whatever might be on the left hand side), is never included in the expression node. 
This PR adds an `expr` parameter to the `IndexExpr` node. Now our tree looks like this:
```json
[
  {
    "type": "ExprStmt",
    "expr": {
      "type": "=",
      "expr": {
        "type": "IndexExpr",
        "expr": {
          "type": "IdentifierExpr",
          "value": "array"
        },
        "args": [
          {
            "type": "LiteralExpr",
            "value": "1"
          }
        ]
      },
      "value": {
        "type": "IdentifierExpr",
        "value": "v"
      }
    }
  }
]
```

_Oh, and there's also a small documentation addition for `clib.named_struct()` which I accidentally committed._ :sweat_smile: 