### PR TITLE
ast: Fix `UsingStmt` and `InterpolationExpr`

### DIFF
--- a/libs/ast/parser.b
+++ b/libs/ast/parser.b
@@ -749,14 +749,16 @@ class Parser {
 
         if [TokenType.DOC, TokenType.COMMENT, TokenType.NEWLINE].contains(self._previous().type) {}
         else if self._previous().type == TokenType.WHEN {
-          var tmp_cases = []
+          var conditions = []
+
           do {
             self._ignore_newline()
-
-            tmp_cases.append(self._expression())
+            conditions.append(self._expression())
           } while self._match(TokenType.COMMA)
+
           var stmt = self._statement()
-          cases.append(CaseStmt(tmp_cases, stmt))
+          cases.append(CaseStmt(conditions, stmt))
+
         } else {
           state = 1
           default_case = self._statement()

--- a/libs/ast/parser.b
+++ b/libs/ast/parser.b
@@ -734,7 +734,7 @@ class Parser {
    */
   _using() {
     var expr = self._expression()
-    var cases = {}
+    var cases = []
     var default_case
 
     self._consume(TokenType.LBRACE, "'{' expected after using expression")
@@ -752,14 +752,11 @@ class Parser {
           var tmp_cases = []
           do {
             self._ignore_newline()
-            
+
             tmp_cases.append(self._expression())
           } while self._match(TokenType.COMMA)
           var stmt = self._statement()
-
-          for tmp in tmp_cases {
-            cases[tmp] = stmt
-          }
+          cases.append(CaseStmt(tmp_cases, stmt))
         } else {
           state = 1
           default_case = self._statement()

--- a/libs/ast/scanner.b
+++ b/libs/ast/scanner.b
@@ -263,14 +263,14 @@ class Scanner {
    */
   _string(c) {
     while self._peek() != c and !self._is_at_end() {
-      if self._peek() == '$' and self._next() == '{' and
-        self._previous() != '\\' {  # interpolation started
+      # interpolation expression
+      if self._peek() == '$' and self._next() == '{' and self._previous() != '\\' {
+        self._current++
+        self._current++
 
         if self._interpolating.length() < self._max_interpolation_nest {
           self._interpolating.append(c)
-          self._current++
           self._add_token(TokenType.INTERPOLATION)
-          self._current++
           return
         }
 

--- a/libs/ast/scanner.b
+++ b/libs/ast/scanner.b
@@ -287,7 +287,7 @@ class Scanner {
       raise Exception('unterminated string on line ${self._line}')
 
     self._match(c)
-    self._add_token(TokenType.LITERAL, self.source[self._start + 1, self._current - 1])
+    self._add_token(TokenType.LITERAL, self.source[self._start, self._current])
   }
 
   /**

--- a/libs/ast/stmt.b
+++ b/libs/ast/stmt.b
@@ -323,6 +323,32 @@ class UsingStmt < Stmt {
 }
 
 /**
+ * Case Stmt representation.
+ * 
+ * @serializable
+ */
+class CaseStmt < Stmt {
+
+  /**
+   * @param {Stmt|any|nil} conditions
+   * @param {Stmt|any|nil} statement
+   * @constructor
+   */
+  CaseStmt(conditions, statement) {
+    self.conditions = conditions
+    self.statement = statement
+  }
+
+  @to_json() {
+    return {
+      type: 'CaseStmt',
+      conditions: self.conditions,
+      statement: self.statement,
+    }
+  }
+}
+
+/**
  * Import Stmt representation.
  * 
  * @serializable

--- a/scripts/ast.b
+++ b/scripts/ast.b
@@ -53,6 +53,7 @@ var asts = {
       Return: ['value'],
       Assert: ['expr', 'message'],
       Using: ['expr', 'cases', 'default_case'],
+      Case: ['conditions', 'statement'],
       Import: ['path', 'elements'],
       Catch: ['body', 'var_name'],
       Comment: ['data'],


### PR DESCRIPTION
# Reproducing
Try running the following code code:
```scala
import ast

var content = "echo 'Hello \${world}'

using x {
    when 1 echo 'foo'
    when 2, 3 echo 'bar'
}
"

var tree = ast.parse(content)
echo json.encode(tree, false)
```

# Errors
What you'll get is the following AST:
```json
[
  {
    "type": "EchoStmt",
    "value": {
      "type": "InterpolationExpr",
      "data": [
        {
          "type": "LiteralExpr",
          "value": "'Hello $"
        },
        {
          "type": "IdentifierExpr",
          "value": "world"
        },
        {
          "type": "LiteralExpr",
          "value": "}'"
        },
        null,
        {
          "type": "LiteralExpr",
          "value": "}'"
        }
      ]
    }
  },
  {
    "type": "UsingStmt",
    "expr": {
      "type": "IdentifierExpr",
      "value": "x"
    },
    "cases": {
      "<instance of LiteralExpr>": {
        "type": "EchoStmt",
        "value": {
          "type": "LiteralExpr",
          "value": "bar"
        }
      }
    },
    "default_case": null
  }
]
```

The `EchoStmt` contains the values `["'Hello $", world, "}", null, "}"]`.
- Where is the opening brace `{`
- Where is the closing quote?
- Why is the closing brace repeated twice with a `nil` in between?

The `UsingStmt` only contains the expression, but not the conditions. So we can only recreate this part of the using statement if we wanted to:
```
using x {
  when echo 'bar'
}
```

Where are the other cases? Where is the condition `when 1`?

# Fixes
If we were to rerun the code with these PR changes we'd get the following AST:
```json
[
  {
    "type": "EchoStmt",
    "value": {
      "type": "InterpolationExpr",
      "data": [
        {
          "type": "LiteralExpr",
          "value": "'Hello ${"    # we include the opening brace
        },
        {
          "type": "IdentifierExpr",
          "value": "world"
        },
        {
          "type": "LiteralExpr",
          "value": "}'"           # we include the ending quote + avoid repeated values
        },
        null
      ]
    }
  },
  {
    "type": "UsingStmt",
    "expr": {
      "type": "IdentifierExpr",
      "value": "x"
    },
    "cases": [                    # we have all the cases
      {
        "type": "CaseStmt",
        "conditions": [           # each case can have multiple conditions
          {
            "type": "LiteralExpr",
            "value": "1"
          }
        ],
        "statement": {
          "type": "EchoStmt",
          "value": {
            "type": "LiteralExpr",
            "value": "'foo'"
          }
        }
      },
      {
        "type": "CaseStmt",
        "conditions": [
          {
            "type": "LiteralExpr",
            "value": "2"
          },
          {
            "type": "LiteralExpr",
            "value": "3"
          }
        ],
        "statement": {
          "type": "EchoStmt",
          "value": {
            "type": "LiteralExpr",
            "value": "'bar'"
          }
        }
      }
    ],
    "default_case": null
  }
]
```